### PR TITLE
[Add] createRestaurant 메서드 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import * as Joi from 'joi';
+import { Restaurant } from './restaurants/entities/restaurant.entity';
 import { RestaurantsModule } from './restaurants/restaurants.module';
 
 @Module({
@@ -32,8 +33,10 @@ import { RestaurantsModule } from './restaurants/restaurants.module';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD, //postgres는 기본적으로 localhost로 호출하면 pw를 묻지 않는다
       database: process.env.DB_NAME,
-      synchronize: true, //typeorm이d db를 연결할때 현재상태로 migration한다는 뜻임
+      synchronize: process.env.NODE_ENV !== 'prod', //typeorm이d db를 연결할때 현재상태로 migration한다는 뜻임
+      //production에서는 실제 데이터를 가지고 있으므로 위와같이 조건으로 처리
       logging: true, //무슨 일이 일어나는지 console에 나타냄
+      entities: [Restaurant],
     }),
     GraphQLModule.forRoot({
       // autoSchemaFile: join(process.cwd(), 'src/schema.gql'),

--- a/src/restaurants/dtos/create-restaurant.dto.ts
+++ b/src/restaurants/dtos/create-restaurant.dto.ts
@@ -1,30 +1,15 @@
 //dto: data transfer object
 
-import { ArgsType, Field } from '@nestjs/graphql';
-import { IsString, Length } from 'class-validator';
+import { InputType, OmitType } from '@nestjs/graphql';
+import { Restaurant } from '../entities/restaurant.entity';
 
 // @InputType()
 //input 타입과 다르게 args타입은 분리하여 인자들을 선언하며 사용할 수 있음.
 //input 타입은 그냥 하나의 객체로 보면 됨 (필드 전체를 가진)
-@ArgsType()
-export class CreateRestaurantDto {
-  @Field(() => String)
-  @IsString()
-  @Length(5, 10)
-  name: string;
-
-  @Field(() => Boolean)
-  isVegan: boolean;
-
-  @Field(() => String)
-  @IsString()
-  address: string;
-
-  @Field(() => String)
-  @IsString()
-  ownerName: string;
-
-  @Field(() => String)
-  @IsString()
-  categoryName: string;
-}
+@InputType()
+export class CreateRestaurantDto extends OmitType(
+  Restaurant,
+  ['id'],
+  //이쪽인자에 값을 넣으면 Type을 변경할 수 있음 :)
+  InputType,
+) {}

--- a/src/restaurants/dtos/create-restaurant.dto.ts
+++ b/src/restaurants/dtos/create-restaurant.dto.ts
@@ -8,19 +8,23 @@ import { IsString, Length } from 'class-validator';
 //input 타입은 그냥 하나의 객체로 보면 됨 (필드 전체를 가진)
 @ArgsType()
 export class CreateRestaurantDto {
-  @Field((type) => String)
+  @Field(() => String)
   @IsString()
   @Length(5, 10)
   name: string;
 
-  @Field((type) => Boolean)
+  @Field(() => Boolean)
   isVegan: boolean;
 
-  @Field((type) => String)
+  @Field(() => String)
   @IsString()
   address: string;
 
   @Field(() => String)
   @IsString()
   ownerName: string;
+
+  @Field(() => String)
+  @IsString()
+  categoryName: string;
 }

--- a/src/restaurants/dtos/update-restaurant.dto.ts
+++ b/src/restaurants/dtos/update-restaurant.dto.ts
@@ -2,9 +2,7 @@ import { Field, InputType, PartialType } from '@nestjs/graphql';
 import { CreateRestaurantDto } from './create-restaurant.dto';
 
 @InputType()
-export class UpdateRestaurantInputType extends PartialType(
-  CreateRestaurantDto,
-) {}
+class UpdateRestaurantInputType extends PartialType(CreateRestaurantDto) {}
 
 @InputType()
 export class UpdateRestaurantDto {

--- a/src/restaurants/dtos/update-restaurant.dto.ts
+++ b/src/restaurants/dtos/update-restaurant.dto.ts
@@ -1,0 +1,16 @@
+import { Field, InputType, PartialType } from '@nestjs/graphql';
+import { CreateRestaurantDto } from './create-restaurant.dto';
+
+@InputType()
+export class UpdateRestaurantInputType extends PartialType(
+  CreateRestaurantDto,
+) {}
+
+@InputType()
+export class UpdateRestaurantDto {
+  @Field(() => Number)
+  id: number;
+
+  @Field(() => UpdateRestaurantInputType)
+  data: UpdateRestaurantInputType;
+}

--- a/src/restaurants/entities/restaurant.entity.ts
+++ b/src/restaurants/entities/restaurant.entity.ts
@@ -1,7 +1,10 @@
 //entity는 database의 모델을 생각하면 된다.
 
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { IsBoolean, IsString, Length } from 'class-validator';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+@InputType({ isAbstract: true }) //스키마는 하나의 type을 가져야하는데 이렇게 isAbstract옵션을 이용함으로서 다른 곳에서 InputType으로서 사용할 수 있음.
+//InputType으로 쓴다는게 아니라 InputType으로도 extend시킨다는 뜻으로 이해하자!
 @ObjectType() //@ObjectType은 graphql이 자동으로 스키마를 빌드하기 위해 사용하는 Graphql decorator이다.
 @Entity() //@Entitysms TypeOrm이 db에 정의한 schema를 저장하게 해주기위해 사용하는 데코레이터이다.
 export class Restaurant {
@@ -12,21 +15,27 @@ export class Restaurant {
 
   @Field(() => String)
   @Column()
+  @IsString()
   name: string;
   //Nullabe 셋팅을 통해 ?연산자로 활용 가능
   @Field(() => Boolean)
   @Column()
+  @IsBoolean()
   isVegan: boolean;
 
   @Field(() => String)
   @Column()
+  @IsString()
   address: string;
 
   @Field(() => String)
   @Column()
+  @IsString()
+  @Length(5)
   ownerName: string;
 
   @Field(() => String)
   @Column()
+  @IsString()
   categoryName: string;
 }

--- a/src/restaurants/entities/restaurant.entity.ts
+++ b/src/restaurants/entities/restaurant.entity.ts
@@ -1,19 +1,32 @@
 //entity는 database의 모델을 생각하면 된다.
 
 import { Field, ObjectType } from '@nestjs/graphql';
-
-@ObjectType()
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+@ObjectType() //@ObjectType은 graphql이 자동으로 스키마를 빌드하기 위해 사용하는 Graphql decorator이다.
+@Entity() //@Entitysms TypeOrm이 db에 정의한 schema를 저장하게 해주기위해 사용하는 데코레이터이다.
 export class Restaurant {
   //graphql관점에서 restaurant가 어떻게 생겼는지 묘샤하기 용도
+  @PrimaryGeneratedColumn()
+  @Field(() => Number)
+  id: number;
+
   @Field(() => String)
+  @Column()
   name: string;
   //Nullabe 셋팅을 통해 ?연산자로 활용 가능
   @Field(() => Boolean)
+  @Column()
   isVegan: boolean;
 
   @Field(() => String)
+  @Column()
   address: string;
 
   @Field(() => String)
+  @Column()
   ownerName: string;
+
+  @Field(() => String)
+  @Column()
+  categoryName: string;
 }

--- a/src/restaurants/entities/restaurant.entity.ts
+++ b/src/restaurants/entities/restaurant.entity.ts
@@ -1,7 +1,7 @@
 //entity는 database의 모델을 생각하면 된다.
 
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { IsBoolean, IsString, Length } from 'class-validator';
+import { IsBoolean, IsOptional, IsString, Length } from 'class-validator';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 @InputType({ isAbstract: true }) //스키마는 하나의 type을 가져야하는데 이렇게 isAbstract옵션을 이용함으로서 다른 곳에서 InputType으로서 사용할 수 있음.
 //InputType으로 쓴다는게 아니라 InputType으로도 extend시킨다는 뜻으로 이해하자!
@@ -16,14 +16,18 @@ export class Restaurant {
   @Field(() => String)
   @Column()
   @IsString()
+  @Length(5)
   name: string;
   //Nullabe 셋팅을 통해 ?연산자로 활용 가능
-  @Field(() => Boolean)
-  @Column()
+  @Field(() => Boolean, { nullable: true })
+  //nullable은 createRestaurant 을 찍어보면 따로 mutation할때 값을 넣지 않으면 나오지 않지만 defaultValue는 항상 들어있음 ㅋ
+  //graphql 스키마에서 이필드의 defaultValue 가 true라고 설정
+  @Column({ default: true }) //기본값 설정 //DB에서 defaultValue true tjfwjd
+  @IsOptional() //안보낼 수도 있게 설정 //validation이 optional인것 설정
   @IsBoolean()
   isVegan: boolean;
 
-  @Field(() => String)
+  @Field(() => String, { defaultValue: '금호' })
   @Column()
   @IsString()
   address: string;
@@ -31,7 +35,6 @@ export class Restaurant {
   @Field(() => String)
   @Column()
   @IsString()
-  @Length(5)
   ownerName: string;
 
   @Field(() => String)

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Restaurant } from './entities/restaurant.entity';
 import { RestaurantResolver } from './restaurants.resolver';
+import { RestaurantService } from './restaurants.service';
 
 @Module({
-  providers: [RestaurantResolver],
+  imports: [TypeOrmModule.forFeature([Restaurant])],
+  providers: [RestaurantResolver, RestaurantService],
 })
 export class RestaurantsModule {}

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { CreateRestaurantDto } from './dtos/create-restaurant.dto';
+import { UpdateRestaurantDto } from './dtos/update-restaurant.dto';
 import { Restaurant } from './entities/restaurant.entity';
 import { RestaurantService } from './restaurants.service';
 
@@ -15,9 +16,10 @@ export class RestaurantResolver {
   restaurants(): Promise<Restaurant[]> {
     return this.restaurantService.getAll();
   }
-  @Mutation(() => Boolean)
+
   //createRestaurant 에 일일이 arguments로서 restaurant.entity.ts에 있는 필드들을 필요한 것만 정의해서 Arg를 길게 가져 가도 됨
   // 그러나 inputType을 설정하여 객체를 전체로 넘겨서 쓸 수 도 있음
+  @Mutation(() => Boolean)
   async createRestaurant(
     @Args('input') createRestaurantDto: CreateRestaurantDto,
   ): Promise<boolean> {
@@ -29,5 +31,12 @@ export class RestaurantResolver {
       console.error(error);
       return false;
     }
+  }
+
+  @Mutation(() => Boolean)
+  async updateRestaurant(
+    @Args('input') UpdateRestaurantDto: UpdateRestaurantDto,
+  ) {
+    return true;
   }
 }

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -19,7 +19,7 @@ export class RestaurantResolver {
   //createRestaurant 에 일일이 arguments로서 restaurant.entity.ts에 있는 필드들을 필요한 것만 정의해서 Arg를 길게 가져 가도 됨
   // 그러나 inputType을 설정하여 객체를 전체로 넘겨서 쓸 수 도 있음
   async createRestaurant(
-    @Args() createRestaurantDto: CreateRestaurantDto,
+    @Args('input') createRestaurantDto: CreateRestaurantDto,
   ): Promise<boolean> {
     try {
       await this.restaurantService.createRestaurant(createRestaurantDto);

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -36,7 +36,13 @@ export class RestaurantResolver {
   @Mutation(() => Boolean)
   async updateRestaurant(
     @Args('input') UpdateRestaurantDto: UpdateRestaurantDto,
-  ) {
-    return true;
+  ): Promise<boolean> {
+    try {
+      await this.restaurantService.updateRestaurant(UpdateRestaurantDto);
+      return true;
+    } catch (e) {
+      console.log(e);
+      return false;
+    }
   }
 }

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -1,24 +1,32 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { CreateRestaurantDto } from './dtos/create-restaurant.dto';
 import { Restaurant } from './entities/restaurant.entity';
+import { RestaurantService } from './restaurants.service';
 
 //Restaurant클래스의 Resolver가 됨.
 @Resolver(() => Restaurant)
 export class RestaurantResolver {
+  constructor(private readonly restaurantService: RestaurantService) {}
   //Query가 리턴하고자 하는 타입을 리턴하는 함수가 되어야한다. (쿼리 데코레이터 안의 함수)
   //그래프큐엘에서 리턴하는 타입의 표현이랑 ts에서 리턴하는 표현의 차이를 기억하자
   //nest js에서는필요한것을 요청해야함, arguments는 자동으로 나타나지 않기 때문에 @Args로 지정해주고 요청해야하며 타입을 지정해줘야한다.
 
   @Query(() => [Restaurant])
-  restaurants(@Args('veganOnly') veganOnly: boolean): Restaurant[] {
-    console.log(veganOnly);
-    return [];
+  restaurants(): Promise<Restaurant[]> {
+    return this.restaurantService.getAll();
   }
   @Mutation(() => Boolean)
   //createRestaurant 에 일일이 arguments로서 restaurant.entity.ts에 있는 필드들을 필요한 것만 정의해서 Arg를 길게 가져 가도 됨
   // 그러나 inputType을 설정하여 객체를 전체로 넘겨서 쓸 수 도 있음
-  createRestaurant(@Args() createRestaurantDto: CreateRestaurantDto): boolean {
-    console.log(createRestaurantDto);
-    return true;
+  async createRestaurant(
+    @Args() createRestaurantDto: CreateRestaurantDto,
+  ): Promise<boolean> {
+    try {
+      await this.restaurantService.createRestaurant(createRestaurantDto);
+      return true;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
   }
 }

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -23,6 +23,7 @@ export class RestaurantResolver {
   ): Promise<boolean> {
     try {
       await this.restaurantService.createRestaurant(createRestaurantDto);
+      console.log(createRestaurantDto);
       return true;
     } catch (error) {
       console.error(error);

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateRestaurantDto } from './dtos/create-restaurant.dto';
+import { Restaurant } from './entities/restaurant.entity';
+
+@Injectable()
+export class RestaurantService {
+  constructor(
+    @InjectRepository(Restaurant)
+    private readonly restaurants: Repository<Restaurant>,
+  ) {}
+
+  getAll(): Promise<Restaurant[]> {
+    //DB에 접근하는 방식을 여기서 작성하게 됨
+    //여기서의 restaurants가 restaurant entity의 respository이다.
+    return this.restaurants.find();
+  }
+
+  createRestaurant(
+    createRestaurantDto: CreateRestaurantDto,
+  ): Promise<Restaurant> {
+    //create 와 save의 차이를 보자
+    const newRestaurant = this.restaurants.create(createRestaurantDto); // create는 instance를 만들어 줌 -> DB를 실제로 건들지는 않는다는 말.
+    //DB에 실제로 저장하고 싶으면 save를 사용하면 된다.
+    return this.restaurants.save(newRestaurant);
+  }
+}

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateRestaurantDto } from './dtos/create-restaurant.dto';
+import { UpdateRestaurantDto } from './dtos/update-restaurant.dto';
 import { Restaurant } from './entities/restaurant.entity';
 
 @Injectable()
@@ -24,5 +25,9 @@ export class RestaurantService {
     const newRestaurant = this.restaurants.create(createRestaurantDto); // create는 instance를 만들어 줌 -> DB를 실제로 건들지는 않는다는 말.
     //DB에 실제로 저장하고 싶으면 save를 사용하면 된다.
     return this.restaurants.save(newRestaurant);
+  }
+
+  updateRestaurant({ id, data }: UpdateRestaurantDto) {
+    return this.restaurants.update(id, { ...data });
   }
 }


### PR DESCRIPTION
- Mutation 메서드 추가
- dto와 entity 필드 동일하게 추가( not nullable 이기 때문)
- service.ts에서 createRestaurant정의함 
   - create메서드와 save메서드의 차이
   - create: class의 instance를 만듦
   - save: 실제 db에 저장함

 - dto와 entity에 공통으로 선언되어 있던 필드 코드들을 OmitType을 통해
  Restaurant클래스(entitiy에 있는것)을 extends하여 중복 코드를 줄임
    - @InputType 데코레이터의 isAbstract 옵션을 통해 ObjectType으로
  명시되어있지만 InputType으로도 확장 가능할 수 있게만듦.

- PartialType을 통해서 기존 restaurantdto를 옵셔널로 모두 받고
   - id는 필수로받기 위해서 따로 InputType설정 후 data에 해당
  PartialType으로 extends한 updateRestaurantInputType을 주입함

- query를 돌릴때 nest js는 기본적으로 그냥 db에 던지기 때문에 에러
  발생안함
   - 에러핸들링 추가 필요