### PR TITLE
[Add] 유저정보 변경 로직

### DIFF
--- a/src/common/dtos/output.dto.ts
+++ b/src/common/dtos/output.dto.ts
@@ -1,7 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
-export class MutationOutput {
+export class CoreOutput {
   @Field(() => String, { nullable: true })
   error?: string;
 

--- a/src/common/entities/core.entity.ts
+++ b/src/common/entities/core.entity.ts
@@ -1,10 +1,11 @@
-import { Field } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import {
   CreateDateColumn,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 
+@ObjectType()
 export class CoreEntity {
   @PrimaryGeneratedColumn()
   @Field(() => Number)

--- a/src/jwt/jwt.middleware.ts
+++ b/src/jwt/jwt.middleware.ts
@@ -15,16 +15,18 @@ export class JwtMiddleware implements NestMiddleware {
     if ('x-jwt' in req.headers) {
       const token = req.headers['x-jwt'];
       //ts는 header의 어떤 요소도 array가 될 수 있다고 셋팅되어 있기때문에 .toString()으로 처리
-      const decoded = this.jwtService.verify(token.toString());
-      if (typeof decoded === 'object' && decoded.hasOwnProperty('id')) {
-        try {
+      try {
+        const decoded = this.jwtService.verify(token.toString());
+
+        if (typeof decoded === 'object' && decoded.hasOwnProperty('id')) {
           const user = await this.userService.findByID(decoded['id']);
 
           //put user in req
           req['user'] = user;
-        } catch (error) {}
-      }
+        }
+      } catch (error) {}
     }
+
     next();
   }
 }

--- a/src/users/dtos/create-account.dto.ts
+++ b/src/users/dtos/create-account.dto.ts
@@ -1,5 +1,5 @@
 import { InputType, ObjectType, PickType } from '@nestjs/graphql';
-import { MutationOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from 'src/common/dtos/output.dto';
 import { User } from '../entities/user.entity';
 
 @InputType()
@@ -10,4 +10,4 @@ export class CreateAccountInput extends PickType(User, [
 ]) {}
 
 @ObjectType()
-export class CreateAccountOutPut extends MutationOutput {}
+export class CreateAccountOutPut extends CoreOutput {}

--- a/src/users/dtos/edit-profile.dto.ts
+++ b/src/users/dtos/edit-profile.dto.ts
@@ -1,0 +1,14 @@
+import { InputType, ObjectType, PartialType, PickType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { User } from '../entities/user.entity';
+
+@ObjectType()
+export class EditProfileOutput extends CoreOutput {}
+
+@InputType()
+export class EditProfileInput extends PartialType(
+  PickType(User, ['email', 'password']),
+) {
+  //PickType을 통해 User로 부터 필요한 요소만 가져오고
+  //PartialType을 통해 optional하게 사용함
+}

--- a/src/users/dtos/login.dto.ts
+++ b/src/users/dtos/login.dto.ts
@@ -1,9 +1,9 @@
 import { Field, InputType, ObjectType, PickType } from '@nestjs/graphql';
-import { MutationOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from 'src/common/dtos/output.dto';
 import { User } from 'src/users/entities/user.entity';
 
 @ObjectType()
-export class LoginOutput extends MutationOutput {
+export class LoginOutput extends CoreOutput {
   @Field(() => String, { nullable: true })
   token?: string;
 }

--- a/src/users/dtos/user-profile.dto.ts
+++ b/src/users/dtos/user-profile.dto.ts
@@ -1,0 +1,15 @@
+import { ArgsType, Field, ObjectType } from '@nestjs/graphql';
+import { MutationOutput } from 'src/common/dtos/output.dto';
+import { User } from '../entities/user.entity';
+
+@ArgsType()
+export class UserProfileInput {
+  @Field(() => Number)
+  userId: number;
+}
+
+@ObjectType()
+export class UserProfileOutput extends MutationOutput {
+  @Field(() => User, { nullable: true })
+  user?: User;
+}

--- a/src/users/dtos/user-profile.dto.ts
+++ b/src/users/dtos/user-profile.dto.ts
@@ -1,5 +1,5 @@
 import { ArgsType, Field, ObjectType } from '@nestjs/graphql';
-import { MutationOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from 'src/common/dtos/output.dto';
 import { User } from '../entities/user.entity';
 
 @ArgsType()
@@ -9,7 +9,7 @@ export class UserProfileInput {
 }
 
 @ObjectType()
-export class UserProfileOutput extends MutationOutput {
+export class UserProfileOutput extends CoreOutput {
   @Field(() => User, { nullable: true })
   user?: User;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -8,7 +8,7 @@ import {
 import * as bcrypt from 'bcrypt';
 import { IsEmail, IsEnum } from 'class-validator';
 import { CoreEntity } from 'src/common/entities/core.entity';
-import { BeforeInsert, Column, Entity } from 'typeorm';
+import { BeforeInsert, BeforeUpdate, Column, Entity } from 'typeorm';
 
 // type UserRole = 'client' | 'owenr' | 'delivery';
 
@@ -39,6 +39,7 @@ export class User extends CoreEntity {
   role: UserRole;
 
   @BeforeInsert() //before save in DB with save method in service.ts do this method, when users instance is made by create method
+  @BeforeUpdate()
   async hasPassword(): Promise<void> {
     try {
       this.password = await bcrypt.hash(this.password, 10);

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -2,11 +2,12 @@ import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { AuthGuard } from 'src/auth/auth.guard';
 import { AuthUser } from 'src/auth/auth.user.decorator';
-import { LoginInput, LoginOutput } from 'src/restaurants/dtos/login.dto';
+import { LoginInput, LoginOutput } from 'src/users/dtos/login.dto';
 import {
   CreateAccountInput,
   CreateAccountOutPut,
 } from './dtos/create-account.dto';
+import { EditProfileInput, EditProfileOutput } from './dtos/edit-profile.dto';
 import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
@@ -86,6 +87,25 @@ export class UsersResolver {
       return {
         error: 'User Not Found',
         ok: false,
+      };
+    }
+  }
+
+  @UseGuards(AuthGuard)
+  @Mutation(() => EditProfileOutput)
+  async editProfile(
+    @AuthUser() authUser: User,
+    @Args('input') editProfileInput: EditProfileInput,
+  ): Promise<EditProfileOutput> {
+    try {
+      await this.usersService.editProfile(authUser.id, editProfileInput);
+      return {
+        ok: true,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error,
       };
     }
   }

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -7,17 +7,13 @@ import {
   CreateAccountInput,
   CreateAccountOutPut,
 } from './dtos/create-account.dto';
+import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
 
 @Resolver(() => User)
 export class UsersResolver {
   constructor(private readonly usersService: UsersService) {}
-
-  @Query(() => Boolean)
-  hi() {
-    return true;
-  }
 
   @Mutation(() => CreateAccountOutPut)
   async createAccount(
@@ -67,5 +63,30 @@ export class UsersResolver {
   me(@AuthUser() authUser: User) {
     console.log('@@@@', authUser);
     return authUser;
+  }
+
+  //user profile을 보여주는 query
+
+  @UseGuards(AuthGuard)
+  @Query(() => UserProfileOutput)
+  async userProfile(
+    @Args() userProfileInput: UserProfileInput,
+  ): Promise<UserProfileOutput> {
+    try {
+      const user = await this.usersService.findByID(userProfileInput.userId);
+      if (!user) {
+        throw Error();
+      }
+
+      return {
+        ok: true,
+        user,
+      };
+    } catch (e) {
+      return {
+        error: 'User Not Found',
+        ok: false,
+      };
+    }
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -80,7 +80,11 @@ export class UsersService {
     return this.users.findOne({ id });
   }
 
-  async editProfile(userId: number, editProfileInput: EditProfileInput) {
+  async editProfile(
+    userId: number,
+    { email, password }: EditProfileInput,
+  ): Promise<User> {
+    //1.
     //update의 경우 Entitiy를 업데이트하지만 Db에 존재하는지 확인을 하지 않음
     //이 프로젝트의 경우 cookie에서 token을 가져와서 userId를 받아오는 것이 전제로 되어있음
     // 그래서 userId를 신뢰할 수 있다는 전제하에 update()메서드를 사용하게 됨
@@ -88,10 +92,25 @@ export class UsersService {
     //그리고 로그인 되어있지 않다면 누구도 eidtprofile을건드릴 수 없는 구조임
     // console.log('@@@@', userId, email, password);
 
+    //2.
     //destructuring으로 email, password를 따로 받을 시에 password가
     //기입되지 않으면 undefined로 나타나서 db에 넣을 수 없으므로 에러가발생함
     //그래서 edtiProfileInput을 그대로 받고 스프레드복사를 통해서 null값으로 넘겨주는 것
-    console.log('@@@', editProfileInput);
-    this.users.update(userId, { ...editProfileInput });
+
+    //3.
+    //update는 entity를 체크하지 않으므로 @BeforeUPdate를 호출하지 못하게 됨
+    //save는 entities를 체크하고 없으면 db에 create and Insert하고 있으면update를 체크하게 된다.
+
+    const user = await this.users.findOne(userId);
+
+    if (email) {
+      user.email = email;
+    }
+
+    if (password) {
+      user.password = password;
+    }
+
+    return this.users.save(user);
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { JwtService } from 'src/jwt/jwt.service';
-import { LoginInput } from 'src/restaurants/dtos/login.dto';
+import { LoginInput } from 'src/users/dtos/login.dto';
 import { Repository } from 'typeorm';
 import { CreateAccountInput } from './dtos/create-account.dto';
+import { EditProfileInput } from './dtos/edit-profile.dto';
 import { User } from './entities/user.entity';
 
 @Injectable()
@@ -77,5 +78,20 @@ export class UsersService {
 
   async findByID(id: number): Promise<User> {
     return this.users.findOne({ id });
+  }
+
+  async editProfile(userId: number, editProfileInput: EditProfileInput) {
+    //update의 경우 Entitiy를 업데이트하지만 Db에 존재하는지 확인을 하지 않음
+    //이 프로젝트의 경우 cookie에서 token을 가져와서 userId를 받아오는 것이 전제로 되어있음
+    // 그래서 userId를 신뢰할 수 있다는 전제하에 update()메서드를 사용하게 됨
+    // 그렇지 않고 graphql Input으로 즉시 id를 받는 경우라면 신뢰할 수 없으므로 update메서드를 사용하지 않을 것임.
+    //그리고 로그인 되어있지 않다면 누구도 eidtprofile을건드릴 수 없는 구조임
+    // console.log('@@@@', userId, email, password);
+
+    //destructuring으로 email, password를 따로 받을 시에 password가
+    //기입되지 않으면 undefined로 나타나서 db에 넣을 수 없으므로 에러가발생함
+    //그래서 edtiProfileInput을 그대로 받고 스프레드복사를 통해서 null값으로 넘겨주는 것
+    console.log('@@@', editProfileInput);
+    this.users.update(userId, { ...editProfileInput });
   }
 }


### PR DESCRIPTION
- update 메서드를 통해 entity를 거치지않고 db로 쿼리를 곧바로 보내는
  방식으로 업데이트
- 따라서 @BeforeUpdate 데코레이터가 적용되지 않음
- update -> save 메서드로 변경


   -  throw Error를 try 문안에서해주면 catch문으로 에러가 날아감