### PR TITLE
[Add] Edit Restaurant, 카테고리 찾기

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ The Backend Folder
 - category (foreign key)
 - address
 - coverImage
+
+### Resutaurants function
+
+- Edit Restaurant
+- Delete Restaurant
+
+- See Categories
+- See Restaurants by Category(pagination)
+- See Restaurants (pagination)
+- See Restaurant
+
+- Create Dish
+- Edit Dish
+- Delete Dish

--- a/src/restaurants/dtos/all-categories.dto.ts
+++ b/src/restaurants/dtos/all-categories.dto.ts
@@ -1,0 +1,9 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Category } from '../entities/category.entity';
+
+@ObjectType()
+export class AllCategoriesOutput extends CoreOutput {
+  @Field(() => [Category], { nullable: true })
+  categories?: Category[];
+}

--- a/src/restaurants/dtos/category.dto.ts
+++ b/src/restaurants/dtos/category.dto.ts
@@ -1,0 +1,15 @@
+import { ArgsType, Field, ObjectType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Category } from '../entities/category.entity';
+
+@ArgsType()
+export class CategoryInput {
+  @Field(() => String)
+  slug: string;
+}
+
+@ObjectType()
+export class CategoryOutput extends CoreOutput {
+  @Field(() => Category, { nullable: true })
+  category?: Category;
+}

--- a/src/restaurants/dtos/delete-restaurant.dto.ts
+++ b/src/restaurants/dtos/delete-restaurant.dto.ts
@@ -1,0 +1,11 @@
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+
+@InputType()
+export class DeleteRestaurantInput {
+  @Field(() => Number)
+  restaurantId: number;
+}
+
+@ObjectType()
+export class DeleteRestaurantOutput extends CoreOutput {}

--- a/src/restaurants/dtos/edit-restaurant.dto.ts
+++ b/src/restaurants/dtos/edit-restaurant.dto.ts
@@ -1,0 +1,12 @@
+import { Field, InputType, ObjectType, PartialType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CreateRestaurantInput } from './create-restaurant.dto';
+
+@InputType()
+export class EditRestaurantInput extends PartialType(CreateRestaurantInput) {
+  @Field(() => Number)
+  restaurantId: number;
+}
+
+@ObjectType()
+export class EditRestaurantOutput extends CoreOutput {}

--- a/src/restaurants/entities/restaurant.entity.ts
+++ b/src/restaurants/entities/restaurant.entity.ts
@@ -4,7 +4,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { IsString, Length } from 'class-validator';
 import { CoreEntity } from 'src/common/entities/core.entity';
 import { User } from 'src/users/entities/user.entity';
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToOne, RelationId } from 'typeorm';
 import { Category } from './category.entity';
 @InputType('RestaurantInputType', { isAbstract: true }) //스키마는 하나의 type을 가져야하는데 이렇게 isAbstract옵션을 이용함으로서 다른 곳에서 InputType으로서 사용할 수 있음.
 //InputType으로 쓴다는게 아니라 InputType으로도 extend시킨다는 뜻으로 이해하자!
@@ -22,7 +22,7 @@ export class Restaurant extends CoreEntity {
   @IsString()
   coverImg: string;
 
-  @Field(() => String, { defaultValue: '금호' })
+  @Field(() => String)
   @Column()
   @IsString()
   address: string;
@@ -40,4 +40,9 @@ export class Restaurant extends CoreEntity {
     onDelete: 'CASCADE',
   })
   owner: User;
+
+  //graphql에는 정의하지 않고 typeorm에만 정의해서 사용 > type script에서 restaurant의 owner column은 User타입으로 정의되어 있는데
+  // 이때 새로운 owner만의 id값을 받아오고 싶기 때문이다.
+  @RelationId((restaurant: Restaurant) => restaurant.owner)
+  ownerId: number;
 }

--- a/src/restaurants/respositories/category.repository.ts
+++ b/src/restaurants/respositories/category.repository.ts
@@ -1,0 +1,19 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { Category } from '../entities/category.entity';
+
+@EntityRepository(Category)
+export class CategoryRepository extends Repository<Category> {
+  async getOrCreate(name: string): Promise<Category> {
+    const categoryName = name.trim().toLowerCase();
+    const categorySlug = categoryName.replace(/ /g, '-');
+    let category = await this.findOne({ slug: categorySlug });
+
+    if (!category) {
+      category = await this.save(
+        this.create({ slug: categorySlug, name: categoryName }),
+      );
+    }
+
+    return category;
+  }
+}

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -2,11 +2,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Restaurant } from './entities/restaurant.entity';
 import { CategoryRepository } from './respositories/category.repository';
-import { RestaurantResolver } from './restaurants.resolver';
+import { CategoryResolver, RestaurantResolver } from './restaurants.resolver';
 import { RestaurantService } from './restaurants.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Restaurant, CategoryRepository])],
-  providers: [RestaurantResolver, RestaurantService],
+  providers: [RestaurantResolver, CategoryResolver, RestaurantService],
 })
 export class RestaurantsModule {}

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Category } from './entities/category.entity';
 import { Restaurant } from './entities/restaurant.entity';
+import { CategoryRepository } from './respositories/category.repository';
 import { RestaurantResolver } from './restaurants.resolver';
 import { RestaurantService } from './restaurants.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Restaurant, Category])],
+  imports: [TypeOrmModule.forFeature([Restaurant, CategoryRepository])],
   providers: [RestaurantResolver, RestaurantService],
 })
 export class RestaurantsModule {}

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -1,7 +1,17 @@
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import {
+  Args,
+  Int,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver,
+} from '@nestjs/graphql';
 import { AuthUser } from 'src/auth/auth.user.decorator';
 import { Role } from 'src/auth/role.decorator';
 import { User } from 'src/users/entities/user.entity';
+import { AllCategoriesOutput } from './dtos/all-categories.dto';
+import { CategoryInput, CategoryOutput } from './dtos/category.dto';
 import {
   CreateRestaurantInput,
   CreateRestaurantOutPut,
@@ -14,6 +24,7 @@ import {
   EditRestaurantInput,
   EditRestaurantOutput,
 } from './dtos/edit-restaurant.dto';
+import { Category } from './entities/category.entity';
 import { Restaurant } from './entities/restaurant.entity';
 import { RestaurantService } from './restaurants.service';
 
@@ -55,5 +66,27 @@ export class RestaurantResolver {
       owner,
       deleteRestaurantInput,
     );
+  }
+}
+
+@Resolver((of) => Category)
+export class CategoryResolver {
+  constructor(private readonly restaurantService: RestaurantService) {}
+
+  //DB, Entity에 저장,선언되는것이 아니고 Res할때 추가로 넣어서 만들어 줄 수가 있게 됨 -> ResolvedField
+  @ResolveField((type) => Int)
+  restaurantCount(@Parent() category: Category): Promise<number> {
+    console.log(category);
+    return this.restaurantService.countRestaurant(category);
+  }
+
+  @Query(() => AllCategoriesOutput)
+  async allCategories(): Promise<AllCategoriesOutput> {
+    return await this.restaurantService.allCategories();
+  }
+
+  @Query(() => CategoryOutput)
+  category(@Args() categoryInput: CategoryInput): Promise<CategoryOutput> {
+    return this.restaurantService.findCategoryBySlug(categoryInput);
   }
 }

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -7,6 +7,10 @@ import {
   CreateRestaurantOutPut,
 } from './dtos/create-restaurant.dto';
 import {
+  DeleteRestaurantInput,
+  DeleteRestaurantOutput,
+} from './dtos/delete-restaurant.dto';
+import {
   EditRestaurantInput,
   EditRestaurantOutput,
 } from './dtos/edit-restaurant.dto';
@@ -39,5 +43,17 @@ export class RestaurantResolver {
     @Args('input') editRestaurantInput: EditRestaurantInput,
   ): Promise<EditRestaurantOutput> {
     return this.restaurantService.editRestaurant(owner, editRestaurantInput);
+  }
+
+  @Mutation(() => EditRestaurantOutput)
+  @Role(['Owner'])
+  deleteRestaurant(
+    @AuthUser() owner: User,
+    @Args('input') deleteRestaurantInput: DeleteRestaurantInput,
+  ): Promise<DeleteRestaurantOutput> {
+    return this.restaurantService.deleteRestaurant(
+      owner,
+      deleteRestaurantInput,
+    );
   }
 }

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -6,6 +6,10 @@ import {
   CreateRestaurantInput,
   CreateRestaurantOutPut,
 } from './dtos/create-restaurant.dto';
+import {
+  EditRestaurantInput,
+  EditRestaurantOutput,
+} from './dtos/edit-restaurant.dto';
 import { Restaurant } from './entities/restaurant.entity';
 import { RestaurantService } from './restaurants.service';
 
@@ -26,5 +30,14 @@ export class RestaurantResolver {
       authUser,
       createRestaurantInput,
     );
+  }
+
+  @Mutation(() => EditRestaurantOutput)
+  @Role(['Owner'])
+  editRestaurant(
+    @AuthUser() owner: User,
+    @Args('input') editRestaurantInput: EditRestaurantInput,
+  ): Promise<EditRestaurantOutput> {
+    return this.restaurantService.editRestaurant(owner, editRestaurantInput);
   }
 }

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'src/users/entities/user.entity';
 import { Repository } from 'typeorm';
+import { AllCategoriesOutput } from './dtos/all-categories.dto';
+import { CategoryInput, CategoryOutput } from './dtos/category.dto';
 import {
   CreateRestaurantInput,
   CreateRestaurantOutPut,
@@ -128,5 +130,48 @@ export class RestaurantService {
     }
 
     return { ok: true };
+  }
+
+  async allCategories(): Promise<AllCategoriesOutput> {
+    try {
+      const categories = await this.categories.find();
+      return {
+        ok: true,
+        categories,
+      };
+    } catch {
+      return {
+        ok: false,
+        error: 'Could not load categories',
+      };
+    }
+  }
+
+  countRestaurant(category: Category) {
+    return this.restaurants.count({ category });
+  }
+
+  async findCategoryBySlug({ slug }: CategoryInput): Promise<CategoryOutput> {
+    try {
+      const category = await this.categories.findOne(
+        { slug },
+        { relations: ['restaurants'] },
+      );
+      if (!category) {
+        return {
+          ok: false,
+          error: 'Category not found',
+        };
+      }
+      return {
+        ok: true,
+        category,
+      };
+    } catch {
+      return {
+        ok: false,
+        error: 'Could not find categories',
+      };
+    }
   }
 }

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -7,6 +7,10 @@ import {
   CreateRestaurantOutPut,
 } from './dtos/create-restaurant.dto';
 import {
+  DeleteRestaurantInput,
+  DeleteRestaurantOutput,
+} from './dtos/delete-restaurant.dto';
+import {
   EditRestaurantInput,
   EditRestaurantOutput,
 } from './dtos/edit-restaurant.dto';
@@ -89,6 +93,38 @@ export class RestaurantService {
       ]);
     } catch {
       return { ok: false, error: 'Could not eidt Restaurant' };
+    }
+
+    return { ok: true };
+  }
+
+  async deleteRestaurant(
+    owner: User,
+    { restaurantId }: DeleteRestaurantInput,
+  ): Promise<DeleteRestaurantOutput> {
+    try {
+      const restaurant = await this.restaurants.findOne(restaurantId);
+
+      if (!restaurant) {
+        return {
+          ok: false,
+          error: 'Restaurant not found',
+        };
+      }
+
+      if (owner.id !== restaurant.ownerId) {
+        return {
+          ok: false,
+          error: "You can't delete a restaurant that you don't own",
+        };
+      }
+
+      await this.restaurants.delete(restaurantId);
+      return {
+        ok: true,
+      };
+    } catch {
+      return { ok: false, error: 'Could not delete Restaurant' };
     }
 
     return { ok: true };

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -6,16 +6,20 @@ import {
   CreateRestaurantInput,
   CreateRestaurantOutPut,
 } from './dtos/create-restaurant.dto';
+import {
+  EditRestaurantInput,
+  EditRestaurantOutput,
+} from './dtos/edit-restaurant.dto';
 import { Category } from './entities/category.entity';
 import { Restaurant } from './entities/restaurant.entity';
+import { CategoryRepository } from './respositories/category.repository';
 
 @Injectable()
 export class RestaurantService {
   constructor(
     @InjectRepository(Restaurant)
     private readonly restaurants: Repository<Restaurant>,
-    @InjectRepository(Category)
-    private readonly categories: Repository<Category>,
+    private readonly categories: CategoryRepository,
   ) {}
 
   getAll(): Promise<Restaurant[]> {
@@ -32,17 +36,9 @@ export class RestaurantService {
       const newRestaurant = this.restaurants.create(createRestaurantInput);
       newRestaurant.owner = owner;
 
-      const categoryName = createRestaurantInput.categoryName
-        .trim()
-        .toLowerCase();
-      const categorySlug = categoryName.replace(/ /g, '-');
-      let category = await this.categories.findOne({ slug: categorySlug });
-
-      if (!category) {
-        category = await this.categories.save(
-          this.categories.create({ slug: categorySlug, name: categoryName }),
-        );
-      }
+      const category = await this.categories.getOrCreate(
+        createRestaurantInput.categoryName,
+      );
 
       newRestaurant.category = category;
       await this.restaurants.save(newRestaurant);
@@ -52,5 +48,49 @@ export class RestaurantService {
     } catch {
       return { ok: false, error: 'Could not create restaurant' };
     }
+  }
+
+  async editRestaurant(
+    owner: User,
+    editRestaurantInput: EditRestaurantInput,
+  ): Promise<EditRestaurantOutput> {
+    try {
+      const restaurant = await this.restaurants.findOne(
+        editRestaurantInput.restaurantId,
+      );
+
+      if (!restaurant) {
+        return {
+          ok: false,
+          error: 'Restaurant not found',
+        };
+      }
+
+      if (owner.id !== restaurant.ownerId) {
+        return {
+          ok: false,
+          error: "You can't edit a restaurant that you don't own",
+        };
+      }
+
+      // defensive programming (발생할 에러를 다 핸들링하여 return 시키고 필요한 로직 생성)
+      let category: Category = null;
+      if (editRestaurantInput.categoryName) {
+        category = await this.categories.getOrCreate(
+          editRestaurantInput.categoryName,
+        );
+      }
+      await this.restaurants.save([
+        {
+          id: editRestaurantInput.restaurantId,
+          ...editRestaurantInput,
+          ...(category && { category }),
+        },
+      ]);
+    } catch {
+      return { ok: false, error: 'Could not eidt Restaurant' };
+    }
+
+    return { ok: true };
   }
 }


### PR DESCRIPTION
- custom repository 생성 (getOrCreate)
- defensive programming > 미리 에러를 처리하는 코드를 다 적어놓고 서비스
  로직을 적는 것
- save 메서드에 아이디 없으면새로생성해버리니 아이디를 꼭
  넣어주자(있으면 수정 없으면 생성을 원할 시)

- 카테고리로 레스토랑 찾기, 모든 카테고리 찾기
   - 레스토랑 관련데이터도 한번에 가져오는 쿼리를 위해서는 서비스에서 메서드 사용 시 relation설정을 꼭해줘야한다.
   - ResolvedField를 활용하면 DB에 해당 로우 이름을 정하지 않고 , dto선언이 없이도 사용가능하다(보통 count를 위해 사용하는 듯)