### PR TITLE
[Add] Dish Table CRUD

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { JwtMiddleware } from './jwt/jwt.middleware';
 import { JwtModule } from './jwt/jwt.module';
 import { MailModule } from './mail/mail.module';
 import { Category } from './restaurants/entities/category.entity';
+import { Dish } from './restaurants/entities/dish.entity';
 import { Restaurant } from './restaurants/entities/restaurant.entity';
 import { RestaurantsModule } from './restaurants/restaurants.module';
 import { User } from './users/entities/user.entity';
@@ -50,7 +51,7 @@ import { UsersModule } from './users/users.module';
       synchronize: process.env.NODE_ENV !== 'prod',
       logging:
         process.env.NODE_ENV !== 'prod' && process.env.NODE_ENV !== 'test',
-      entities: [User, Verification, Restaurant, Category],
+      entities: [User, Verification, Restaurant, Category, Dish],
     }),
     GraphQLModule.forRoot({
       autoSchemaFile: true,

--- a/src/restaurants/dtos/create-dish.dto.ts
+++ b/src/restaurants/dtos/create-dish.dto.ts
@@ -1,0 +1,17 @@
+import { Field, InputType, Int, ObjectType, PickType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Dish } from '../entities/dish.entity';
+
+@InputType()
+export class CreateDishInput extends PickType(Dish, [
+  'name',
+  'price',
+  'description',
+  'options',
+]) {
+  @Field(() => Int)
+  restaurantId: number;
+}
+
+@ObjectType()
+export class CreateDishOutput extends CoreOutput {}

--- a/src/restaurants/dtos/delete-dish.dto.ts
+++ b/src/restaurants/dtos/delete-dish.dto.ts
@@ -1,0 +1,11 @@
+import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+
+@InputType()
+export class DeleteDishInput {
+  @Field(() => Int)
+  dishId: number;
+}
+
+@ObjectType()
+export class DeleteDishOutput extends CoreOutput {}

--- a/src/restaurants/dtos/edit-dish.dto.ts
+++ b/src/restaurants/dtos/edit-dish.dto.ts
@@ -1,0 +1,24 @@
+import {
+  Field,
+  InputType,
+  Int,
+  ObjectType,
+  PartialType,
+  PickType,
+} from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Dish } from '../entities/dish.entity';
+
+@InputType()
+export class EditDishInput extends PickType(PartialType(Dish), [
+  'name',
+  'options',
+  'price',
+  'description',
+]) {
+  @Field(() => Int)
+  dishId: number;
+}
+
+@ObjectType()
+export class EditDishOutput extends CoreOutput {}

--- a/src/restaurants/entities/dish.entity.ts
+++ b/src/restaurants/entities/dish.entity.ts
@@ -10,11 +10,11 @@ class DishOption {
   @Field(() => String)
   name: string;
 
-  @Field(() => [String])
-  choices: string[];
+  @Field(() => [String], { nullable: true })
+  choices?: string[];
 
-  @Field(() => Number)
-  extra: number;
+  @Field(() => Number, { nullable: true })
+  extra?: number;
 }
 
 @InputType('DishInputType', { isAbstract: true })
@@ -32,8 +32,8 @@ export class Dish extends CoreEntity {
   @IsNumber()
   price: number;
 
-  @Field(() => String)
-  @Column({ unique: true })
+  @Field(() => String, { nullable: true })
+  @Column({ nullable: true })
   @IsString()
   //may be url
   photo: string;
@@ -47,6 +47,7 @@ export class Dish extends CoreEntity {
   @Field(() => Restaurant, { nullable: true })
   @ManyToOne(() => Restaurant, (restaurant) => restaurant.menu, {
     onDelete: 'CASCADE', //if the restaurant is deleted the dish would be delted
+    nullable: false,
   })
   restaurant: Restaurant;
 
@@ -55,7 +56,7 @@ export class Dish extends CoreEntity {
 
   //Dish options 를 entity에 넣고싶지 않아서 json파일로 저장할 수 있게됨
   //정형화된 데이터라고 판단되고 굳이 CRUD메서드를 리졸버에서 만드는 수고를하고 싶지 않을 때, 해야할 필요가 없을 때 사용할 수 있음.
-  @Field(() => [DishOption])
-  @Column({ type: 'json' })
-  options: DishOption[];
+  @Field(() => [DishOption], { nullable: true })
+  @Column({ type: 'json', nullable: true })
+  options?: DishOption[];
 }

--- a/src/restaurants/entities/dish.entity.ts
+++ b/src/restaurants/entities/dish.entity.ts
@@ -1,0 +1,61 @@
+import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
+import { IsNumber, IsString, Length } from 'class-validator';
+import { CoreEntity } from 'src/common/entities/core.entity';
+import { Column, Entity, ManyToOne, RelationId } from 'typeorm';
+import { Restaurant } from './restaurant.entity';
+
+@InputType('DishOptionsInputType', { isAbstract: true })
+@ObjectType()
+class DishOption {
+  @Field(() => String)
+  name: string;
+
+  @Field(() => [String])
+  choices: string[];
+
+  @Field(() => Number)
+  extra: number;
+}
+
+@InputType('DishInputType', { isAbstract: true })
+@ObjectType()
+@Entity()
+export class Dish extends CoreEntity {
+  @Field(() => String)
+  @Column({ unique: true })
+  @IsString()
+  @Length(5)
+  name: string;
+
+  @Field(() => Int)
+  @Column()
+  @IsNumber()
+  price: number;
+
+  @Field(() => String)
+  @Column({ unique: true })
+  @IsString()
+  //may be url
+  photo: string;
+
+  @Field(() => String)
+  @Column()
+  @Length(5, 140)
+  description: string;
+
+  // 하나의 레스토랑은 많은 Dish를 가짐, Dish는 하나의 레스토랑을 가짐
+  @Field(() => Restaurant, { nullable: true })
+  @ManyToOne(() => Restaurant, (restaurant) => restaurant.menu, {
+    onDelete: 'CASCADE', //if the restaurant is deleted the dish would be delted
+  })
+  restaurant: Restaurant;
+
+  @RelationId((dish: Dish) => dish.restaurant)
+  restaurantId: number;
+
+  //Dish options 를 entity에 넣고싶지 않아서 json파일로 저장할 수 있게됨
+  //정형화된 데이터라고 판단되고 굳이 CRUD메서드를 리졸버에서 만드는 수고를하고 싶지 않을 때, 해야할 필요가 없을 때 사용할 수 있음.
+  @Field(() => [DishOption])
+  @Column({ type: 'json' })
+  options: DishOption[];
+}

--- a/src/restaurants/entities/dish.entity.ts
+++ b/src/restaurants/entities/dish.entity.ts
@@ -4,14 +4,24 @@ import { CoreEntity } from 'src/common/entities/core.entity';
 import { Column, Entity, ManyToOne, RelationId } from 'typeorm';
 import { Restaurant } from './restaurant.entity';
 
+@InputType('DishChoiceInputType', { isAbstract: true })
+@ObjectType()
+class DishChoice {
+  @Field(() => String)
+  name?: string;
+
+  @Field(() => Int, { nullable: true })
+  extra?: number;
+}
+
 @InputType('DishOptionsInputType', { isAbstract: true })
 @ObjectType()
 class DishOption {
   @Field(() => String)
   name: string;
 
-  @Field(() => [String], { nullable: true })
-  choices?: string[];
+  @Field(() => [DishChoice], { nullable: true })
+  choices?: DishChoice[];
 
   @Field(() => Number, { nullable: true })
   extra?: number;

--- a/src/restaurants/entities/restaurant.entity.ts
+++ b/src/restaurants/entities/restaurant.entity.ts
@@ -4,8 +4,9 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { IsString, Length } from 'class-validator';
 import { CoreEntity } from 'src/common/entities/core.entity';
 import { User } from 'src/users/entities/user.entity';
-import { Column, Entity, ManyToOne, RelationId } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany, RelationId } from 'typeorm';
 import { Category } from './category.entity';
+import { Dish } from './dish.entity';
 @InputType('RestaurantInputType', { isAbstract: true }) //스키마는 하나의 type을 가져야하는데 이렇게 isAbstract옵션을 이용함으로서 다른 곳에서 InputType으로서 사용할 수 있음.
 //InputType으로 쓴다는게 아니라 InputType으로도 extend시킨다는 뜻으로 이해하자!
 @ObjectType() //@ObjectType은 graphql이 자동으로 스키마를 빌드하기 위해 사용하는 Graphql decorator이다.
@@ -45,4 +46,9 @@ export class Restaurant extends CoreEntity {
   // 이때 새로운 owner만의 id값을 받아오고 싶기 때문이다.
   @RelationId((restaurant: Restaurant) => restaurant.owner)
   ownerId: number;
+
+  // 하나의 레스토랑은 많은 Dish를 가짐, Dish는 하나의 레스토랑을 가짐
+  @Field(() => [Dish])
+  @OneToMany(() => Dish, (dish) => dish.restaurant)
+  menu: Dish[];
 }

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -1,12 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Dish } from './entities/dish.entity';
 import { Restaurant } from './entities/restaurant.entity';
 import { CategoryRepository } from './respositories/category.repository';
-import { CategoryResolver, RestaurantResolver } from './restaurants.resolver';
+import {
+  CategoryResolver,
+  DishResolver,
+  RestaurantResolver,
+} from './restaurants.resolver';
 import { RestaurantService } from './restaurants.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Restaurant, CategoryRepository])],
-  providers: [RestaurantResolver, CategoryResolver, RestaurantService],
+  imports: [TypeOrmModule.forFeature([Restaurant, CategoryRepository, Dish])],
+  providers: [
+    RestaurantResolver,
+    CategoryResolver,
+    RestaurantService,
+    DishResolver,
+  ],
 })
 export class RestaurantsModule {}

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -17,10 +17,12 @@ import {
   CreateRestaurantInput,
   CreateRestaurantOutPut,
 } from './dtos/create-restaurant.dto';
+import { DeleteDishInput, DeleteDishOutput } from './dtos/delete-dish.dto';
 import {
   DeleteRestaurantInput,
   DeleteRestaurantOutput,
 } from './dtos/delete-restaurant.dto';
+import { EditDishInput, EditDishOutput } from './dtos/edit-dish.dto';
 import {
   EditRestaurantInput,
   EditRestaurantOutput,
@@ -132,5 +134,23 @@ export class DishResolver {
     @Args('input') creatDishInput: CreateDishInput,
   ): Promise<CreateDishOutput> {
     return this.restaurantService.createDish(owner, creatDishInput);
+  }
+
+  @Mutation(() => EditDishOutput)
+  @Role(['Owner'])
+  editDish(
+    @AuthUser() owner: User,
+    @Args('input') editDishInput: EditDishInput,
+  ): Promise<EditDishOutput> {
+    return this.restaurantService.editDish(owner, editDishInput);
+  }
+
+  @Mutation(() => DeleteDishOutput)
+  @Role(['Owner'])
+  deleteDish(
+    @AuthUser() owner: User,
+    @Args('input') deleteDishInput: DeleteDishInput,
+  ): Promise<DeleteDishOutput> {
+    return this.restaurantService.deleteDish(owner, deleteDishInput);
   }
 }

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -12,6 +12,7 @@ import { Role } from 'src/auth/role.decorator';
 import { User } from 'src/users/entities/user.entity';
 import { AllCategoriesOutput } from './dtos/all-categories.dto';
 import { CategoryInput, CategoryOutput } from './dtos/category.dto';
+import { CreateDishInput, CreateDishOutput } from './dtos/create-dish.dto';
 import {
   CreateRestaurantInput,
   CreateRestaurantOutPut,
@@ -31,6 +32,7 @@ import {
   SearchRestaurantOutput,
 } from './dtos/searchRestaurant.dto';
 import { Category } from './entities/category.entity';
+import { Dish } from './entities/dish.entity';
 import { Restaurant } from './entities/restaurant.entity';
 import { RestaurantService } from './restaurants.service';
 
@@ -116,5 +118,19 @@ export class CategoryResolver {
     @Args('input') categoryInput: CategoryInput,
   ): Promise<CategoryOutput> {
     return this.restaurantService.findCategoryBySlug(categoryInput);
+  }
+}
+
+@Resolver(() => Dish)
+export class DishResolver {
+  constructor(private readonly restaurantService: RestaurantService) {}
+
+  @Mutation(() => CreateDishOutput)
+  @Role(['Owner'])
+  createDish(
+    @AuthUser() owner: User,
+    @Args('input') creatDishInput: CreateDishInput,
+  ): Promise<CreateDishOutput> {
+    return this.restaurantService.createDish(owner, creatDishInput);
   }
 }

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -299,11 +299,10 @@ export class RestaurantService {
         };
       }
 
-      const dish = await this.dishes.save(
+      await this.dishes.save(
         this.dishes.create({ ...createDishInput, restaurant }),
       );
 
-      console.log(dish);
       return {
         ok: true,
       };
@@ -316,28 +315,32 @@ export class RestaurantService {
     }
   }
 
+  async checkDish(owner: User, dishId: number) {
+    const dish = await this.dishes.findOne(dishId, {
+      relations: ['restaurant'],
+    });
+
+    if (!dish) {
+      return {
+        ok: false,
+        error: 'Dish not found',
+      };
+    }
+
+    if (dish.restaurant.ownerId !== owner.id) {
+      return {
+        ok: false,
+        error: "You can't do that.",
+      };
+    }
+  }
+
   async editDish(
     owner: User,
     editDishInput: EditDishInput,
   ): Promise<EditDishOutput> {
     try {
-      const dish = await this.dishes.findOne(editDishInput.dishId, {
-        relations: ['restaurant'],
-      });
-
-      if (!dish) {
-        return {
-          ok: false,
-          error: 'Dish not found',
-        };
-      }
-
-      if (dish.restaurant.ownerId !== owner.id) {
-        return {
-          ok: false,
-          error: "You can't do that.",
-        };
-      }
+      this.checkDish(owner, editDishInput.dishId);
       await this.dishes.save({ id: editDishInput.dishId, ...editDishInput });
 
       return {
@@ -356,23 +359,7 @@ export class RestaurantService {
     { dishId }: DeleteDishInput,
   ): Promise<DeleteDishOutput> {
     try {
-      const dish = await this.dishes.findOne(dishId, {
-        relations: ['restaurant'],
-      });
-
-      if (!dish) {
-        return {
-          ok: false,
-          error: 'Dish not found',
-        };
-      }
-
-      if (dish.restaurant.ownerId !== owner.id) {
-        return {
-          ok: false,
-          error: "You can't do that.",
-        };
-      }
+      this.checkDish(owner, dishId);
       await this.dishes.delete(dishId);
 
       return {

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -9,10 +9,12 @@ import {
   CreateRestaurantInput,
   CreateRestaurantOutPut,
 } from './dtos/create-restaurant.dto';
+import { DeleteDishInput, DeleteDishOutput } from './dtos/delete-dish.dto';
 import {
   DeleteRestaurantInput,
   DeleteRestaurantOutput,
 } from './dtos/delete-restaurant.dto';
+import { EditDishInput, EditDishOutput } from './dtos/edit-dish.dto';
 import {
   EditRestaurantInput,
   EditRestaurantOutput,
@@ -310,6 +312,76 @@ export class RestaurantService {
       return {
         ok: false,
         error: 'Could not create dish',
+      };
+    }
+  }
+
+  async editDish(
+    owner: User,
+    editDishInput: EditDishInput,
+  ): Promise<EditDishOutput> {
+    try {
+      const dish = await this.dishes.findOne(editDishInput.dishId, {
+        relations: ['restaurant'],
+      });
+
+      if (!dish) {
+        return {
+          ok: false,
+          error: 'Dish not found',
+        };
+      }
+
+      if (dish.restaurant.ownerId !== owner.id) {
+        return {
+          ok: false,
+          error: "You can't do that.",
+        };
+      }
+      await this.dishes.save({ id: editDishInput.dishId, ...editDishInput });
+
+      return {
+        ok: true,
+      };
+    } catch {
+      return {
+        ok: false,
+        error: 'Could not delete dish',
+      };
+    }
+  }
+
+  async deleteDish(
+    owner: User,
+    { dishId }: DeleteDishInput,
+  ): Promise<DeleteDishOutput> {
+    try {
+      const dish = await this.dishes.findOne(dishId, {
+        relations: ['restaurant'],
+      });
+
+      if (!dish) {
+        return {
+          ok: false,
+          error: 'Dish not found',
+        };
+      }
+
+      if (dish.restaurant.ownerId !== owner.id) {
+        return {
+          ok: false,
+          error: "You can't do that.",
+        };
+      }
+      await this.dishes.delete(dishId);
+
+      return {
+        ok: true,
+      };
+    } catch {
+      return {
+        ok: false,
+        error: 'Could not delete dish',
       };
     }
   }


### PR DESCRIPTION
- Column 데코레이터의 json타입 옵션을 통해 굳이 CRUD가 필요없는 데이터들은 json형태로 저장할 수 가 있음(예를들어 옵션)
- OneToMany, ManyToOne의 nullalbe 설정은 기본 true이기 때문에 필요한곳에는 확실히 false로 설정을 하자
- 관계가 설정되어 있는 테이블의 id값을 받아오기 위해서는 RelationId 데코레이터를 통해 따로 컬럼을 추가하여 편리하게 사용할 수 있다