### PR TITLE
[Refactor] 기존 jwtMiddleWare를 변경하는 이유

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,7 +2,7 @@ import {
   MiddlewareConsumer,
   Module,
   NestModule,
-  RequestMethod,
+  RequestMethod
 } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
@@ -78,7 +78,7 @@ import { UsersModule } from './users/users.module';
           //그게 아닌 (웹소켓인 경우) connection프로토콜을 이용하므로 다르게 처리
           //웹소켓인 경우 한번 커넥션이 일어날때 말고는 따로 토큰등이 교환되지 않고 서로 연결된 상태를 유지하게 됨
         } else {
-          console.log(connection);
+          // console.log(connection);
         }
       },
     }),
@@ -99,6 +99,8 @@ import { UsersModule } from './users/users.module';
   controllers: [],
   providers: [],
 })
+
+//Authentication Handle by adapting jwtMiddleware
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(JwtMiddleware).forRoutes({

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,15 +1,9 @@
-import {
-  MiddlewareConsumer,
-  Module,
-  NestModule,
-  RequestMethod
-} from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import * as Joi from 'joi';
 import { AuthModule } from './auth/auth.module';
-import { JwtMiddleware } from './jwt/jwt.middleware';
 import { JwtModule } from './jwt/jwt.module';
 import { MailModule } from './mail/mail.module';
 import { OrderItem } from './orders/entities/order-itme.entity';
@@ -68,18 +62,10 @@ import { UsersModule } from './users/users.module';
       installSubscriptionHandlers: true, //서버가 웹소켓 기능을 가지게 만드는 설정
       autoSchemaFile: true,
       context: ({ req, connection }) => {
-        //console.log(req);
-        //웹소켓에 연결할때는 http의 연결과는 다르게 req가 없음 , 연결된 상태면 계속 연결되어 있게됨 -> 쿠키같은게 따로 존재 X
-        //따라서 웹소켓에 맞는 프로토콜이 필요함 -> 그게 connection임
-
-        //http프로토콜인 경우 아래와 같이 req가 존재하므로 기존의 방식대로
-        if (req) {
-          return { user: req['user'] };
-          //그게 아닌 (웹소켓인 경우) connection프로토콜을 이용하므로 다르게 처리
-          //웹소켓인 경우 한번 커넥션이 일어날때 말고는 따로 토큰등이 교환되지 않고 서로 연결된 상태를 유지하게 됨
-        } else {
-          // console.log(connection);
-        }
+        const TOKEN_KEY = 'x-jwt';
+        return {
+          token: req ? req.headers[TOKEN_KEY] : connection.context[TOKEN_KEY],
+        };
       },
     }),
 
@@ -101,12 +87,5 @@ import { UsersModule } from './users/users.module';
 })
 
 //Authentication Handle by adapting jwtMiddleware
-export class AppModule implements NestModule {
-  configure(consumer: MiddlewareConsumer) {
-    consumer.apply(JwtMiddleware).forRoutes({
-      path: '/graphql',
-      method: RequestMethod.POST,
-    });
-  }
-}
+export class AppModule {}
 // export class AppModule {}

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,7 +1,8 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { User } from 'src/users/entities/user.entity';
+import { JwtService } from 'src/jwt/jwt.service';
+import { UsersService } from 'src/users/users.service';
 import { AllowedRoles } from './role.decorator';
 
 //authentication => who are you
@@ -10,30 +11,45 @@ import { AllowedRoles } from './role.decorator';
 @Injectable()
 //CanActivate는 true또는 false밖에 리턴 못함 :)
 export class AuthGuard implements CanActivate {
-  constructor(private readonly reflector: Reflector) {}
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly jwtService: JwtService,
+    private readonly userService: UsersService,
+  ) {}
 
-  canActivate(context: ExecutionContext) {
+  async canActivate(context: ExecutionContext) {
     //셋팅된 메타데이터를 가져오기 위해 Reflector를 사용
     const roles = this.reflector.get<AllowedRoles>(
       'roles',
       context.getHandler(),
     );
-    console.log('In AUTH GUARD', roles);
 
     if (!roles) {
       return true;
     }
 
     const gqlContext = GqlExecutionContext.create(context).getContext();
-    const user: User = gqlContext.user;
-    if (!user) {
+    const token = gqlContext.token;
+
+    if (token) {
+      const decoded = this.jwtService.verify(token.toString());
+
+      if (typeof decoded === 'object' && decoded.hasOwnProperty('id')) {
+        const { user } = await this.userService.findByID(decoded['id']);
+        if (!user) {
+          return false;
+        }
+        gqlContext['user'] = user;
+        if (roles.includes('Any')) {
+          return true;
+        }
+
+        return roles.includes(user.role);
+      } else {
+        return false;
+      }
+    } else {
       return false;
     }
-
-    if (roles.includes('Any')) {
-      return true;
-    }
-
-    return roles.includes(user.role);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
+import { UsersModule } from 'src/users/users.module';
 import { AuthGuard } from './auth.guard';
 
 @Module({
   //기본적으로 전역에 사용할 수 있게 해주는 설정이다(APP_GUARD)
+  imports: [UsersModule],
   providers: [
     {
       provide: APP_GUARD,

--- a/src/orders/orders.resolver.ts
+++ b/src/orders/orders.resolver.ts
@@ -62,7 +62,9 @@ export class OrderResolver {
   }
 
   @Subscription(() => String)
-  readyPotato() {
+  @Role(['Any'])
+  readyPotato(@AuthUser() user: User) {
+    console.log(user);
     return pubsub.asyncIterator('hotPotato');
   }
 }


### PR DESCRIPTION
- 웹소켓은 http가 아닌 connection으로 불리는 인자로 통신함
- 기존 JwtMiddleware는 app.module.ts > configure메서드를 통해 적용
  되었음
- connection까지 적용가능한 미들웨어를 만들기 위해 기존 코드를
  변경해야함