### PR TITLE
[Add] Payment Resolver(read create)

### DIFF
--- a/src/payments/dtos/create-payment.dto.ts
+++ b/src/payments/dtos/create-payment.dto.ts
@@ -1,0 +1,12 @@
+import { InputType, ObjectType, PickType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Payment } from '../entities/payment.entities';
+
+@InputType()
+export class CreatePaymentInput extends PickType(Payment, [
+  'transactionId',
+  'restaurantId',
+]) {}
+
+@ObjectType()
+export class CreatePaymentOutput extends CoreOutput {}

--- a/src/payments/dtos/get-payments.dto.ts
+++ b/src/payments/dtos/get-payments.dto.ts
@@ -1,0 +1,9 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Payment } from '../entities/payment.entities';
+
+@ObjectType()
+export class GetPaymentsOutput extends CoreOutput {
+  @Field(() => [Payment], { nullable: true })
+  payments?: Payment[];
+}

--- a/src/payments/entities/payment.entities.ts
+++ b/src/payments/entities/payment.entities.ts
@@ -8,25 +8,27 @@ import { Column, Entity, ManyToOne, RelationId } from 'typeorm';
 @ObjectType()
 @Entity()
 export class Payment extends CoreEntity {
-  @Field(() => Int)
+  @Field(() => String)
   @Column()
-  transactionId: number;
+  transactionId: string;
 
   @Field(() => User)
   @ManyToOne(() => User, (user) => user.payments, {
     nullable: true,
   })
-  user?: User;
+  user: User;
 
   @RelationId((payment: Payment) => payment.user)
   userId: number;
 
   // 레스토랑에서 payment로 접근할 일이 없기 때문에 retaurant entity에 따로 restaurant를 선언해주지 않는다.
   // 그리고 reverse relation도 따로 선언해주지 않는다.
+  // 공식문서를 보면 설명잘되어있음 oneTomany는 이렇게 선언하지 못함 ㅎㅅㅎ
   @Field(() => Restaurant)
   @ManyToOne(() => Restaurant)
   restaurant: Restaurant;
 
   @RelationId((payment: Payment) => payment.restaurant)
+  @Field(() => Int)
   restaurantId: number;
 }

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -1,4 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Restaurant } from 'src/restaurants/entities/restaurant.entity';
+import { Payment } from './entities/payment.entities';
+import { PaymentResolver } from './payments.resolver';
+import { PaymentService } from './payments.service';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([Payment, Restaurant])],
+  providers: [PaymentService, PaymentResolver],
+})
 export class PaymentsModule {}

--- a/src/payments/payments.resolver.ts
+++ b/src/payments/payments.resolver.ts
@@ -1,0 +1,24 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { AuthUser } from 'src/auth/auth.user.decorator';
+import { Role } from 'src/auth/role.decorator';
+import { User } from 'src/users/entities/user.entity';
+import {
+  CreatePaymentInput,
+  CreatePaymentOutput,
+} from './dtos/create-payment.dto';
+import { Payment } from './entities/payment.entities';
+import { PaymentService } from './payments.service';
+
+@Resolver((of) => Payment)
+export class PaymentResolver {
+  constructor(private readonly paymentService: PaymentService) {}
+
+  @Mutation(() => CreatePaymentOutput)
+  @Role(['Owner'])
+  createPayment(
+    @AuthUser() owner: User,
+    @Args('input') createPaymentInput: CreatePaymentInput,
+  ): Promise<CreatePaymentOutput> {
+    return this.paymentService.createPayment(owner, createPaymentInput);
+  }
+}

--- a/src/payments/payments.resolver.ts
+++ b/src/payments/payments.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { AuthUser } from 'src/auth/auth.user.decorator';
 import { Role } from 'src/auth/role.decorator';
 import { User } from 'src/users/entities/user.entity';
@@ -6,6 +6,7 @@ import {
   CreatePaymentInput,
   CreatePaymentOutput,
 } from './dtos/create-payment.dto';
+import { GetPaymentsOutput } from './dtos/get-payments.dto';
 import { Payment } from './entities/payment.entities';
 import { PaymentService } from './payments.service';
 
@@ -20,5 +21,11 @@ export class PaymentResolver {
     @Args('input') createPaymentInput: CreatePaymentInput,
   ): Promise<CreatePaymentOutput> {
     return this.paymentService.createPayment(owner, createPaymentInput);
+  }
+
+  @Query(() => GetPaymentsOutput)
+  @Role(['Owner'])
+  getPayments(@AuthUser() user: User): Promise<GetPaymentsOutput> {
+    return this.paymentService.getPayment(user);
   }
 }

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Restaurant } from 'src/restaurants/entities/restaurant.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Repository } from 'typeorm';
+import {
+  CreatePaymentInput,
+  CreatePaymentOutput,
+} from './dtos/create-payment.dto';
+import { Payment } from './entities/payment.entities';
+
+@Injectable()
+export class PaymentService {
+  constructor(
+    @InjectRepository(Payment)
+    private readonly payments: Repository<Payment>,
+    @InjectRepository(Restaurant)
+    private readonly restaurants: Repository<Restaurant>,
+  ) {}
+
+  async createPayment(
+    owner: User,
+    { restaurantId, transactionId }: CreatePaymentInput,
+  ): Promise<CreatePaymentOutput> {
+    try {
+      // const restaurant = await this.restaurant.findOne(
+      //   restaurantId,
+      // );
+      const restaurant = await this.restaurants.findOne(restaurantId);
+
+      if (!restaurant) {
+        return {
+          ok: false,
+          error: 'Restaurant not found',
+        };
+      }
+
+      if (restaurant.ownerId !== owner.id) {
+        return {
+          ok: false,
+          error: 'You are not allowed to do this',
+        };
+      }
+
+      await this.payments.save(
+        this.payments.create({
+          transactionId,
+          user: owner,
+          restaurant,
+        }),
+      );
+
+      return {
+        ok: true,
+      };
+    } catch {
+      return {
+        ok: false,
+        error: 'Could not create payment',
+      };
+    }
+  }
+}

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -7,6 +7,7 @@ import {
   CreatePaymentInput,
   CreatePaymentOutput,
 } from './dtos/create-payment.dto';
+import { GetPaymentsOutput } from './dtos/get-payments.dto';
 import { Payment } from './entities/payment.entities';
 
 @Injectable()
@@ -57,6 +58,22 @@ export class PaymentService {
       return {
         ok: false,
         error: 'Could not create payment',
+      };
+    }
+  }
+
+  async getPayment(user: User): Promise<GetPaymentsOutput> {
+    try {
+      const payments = await this.payments.find({ user });
+
+      return {
+        ok: true,
+        payments,
+      };
+    } catch {
+      return {
+        ok: false,
+        error: 'Could not load payments',
       };
     }
   }


### PR DESCRIPTION
- Not ManyToOne need to have reverse def. when it's not useful but OneToMany should have reverse definition if useless
- {eager : true} option can access every relation table when it's called but it'd be problem when testing else